### PR TITLE
flip text rotation to match cairo's coordinate system

### DIFF
--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -503,7 +503,7 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Text)
         set_font_matrix(ctx, mat)
         # set_font_size(ctx, 16)
         # TODO this only works in 2d
-        Cairo.rotate(ctx, 2acos(r[4]))
+        Cairo.rotate(ctx, -2acos(r[4]))
         Cairo.show_text(ctx, string(char))
         Cairo.restore(ctx)
     end


### PR DESCRIPTION
this fixes jumbled y labels in makielayout (and all other rotated text)