### PR TITLE
fix poly drawing with smarter methods for single colors and rects

### DIFF
--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -254,7 +254,7 @@ function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
 
     AbstractPlotting.interpolated_getindex.(
         Ref(colormap),
-        numbers,
+        Float64.(numbers), # ints don't work in AbstractPlotting
         Ref(colorrange))
 end
 

--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -544,7 +544,7 @@ function draw_poly(scene::Scene, screen::CairoScreen, poly, points::Vector{<:Poi
         return
     end
 
-    model = Mat4f0(I)
+    model = poly.model[]
     points = project_position.(Ref(scene), points, Ref(model))
     Cairo.move_to(screen.context, points[1]...)
     for p in points[2:end]
@@ -565,7 +565,7 @@ function project_rect(scene, rect::Rect, model)
 end
 
 function draw_poly(scene::Scene, screen::CairoScreen, poly, rects::Vector{<:Rect2D})
-    model = Mat4f0(I)
+    model = poly.model[]
     projected_rects = project_rect.(Ref(scene), rects, Ref(model))
 
     color = poly.color[]

--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -504,9 +504,6 @@ Special method for polys so we don't fall back to atomic meshes, which are much 
 complex and slower to draw than standard paths with single color.
 """
 function draw_plot(scene::Scene, screen::CairoScreen, poly::Poly)
-    if poly.visible[] == false
-        return
-    end
     # dispatch on input arguments to poly to use smarter drawing methods than
     # meshes if possible
     draw_poly(scene, screen, poly, to_value.(poly.input_args)...)

--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -510,14 +510,25 @@ function draw_plot(scene::Scene, screen::CairoScreen, poly::Poly)
 end
 
 """
-Fallback method for unknown args just draws mesh and lines.
+Fallback method for args without special treatment.
 """
 function draw_poly(scene::Scene, screen::CairoScreen, poly, args...)
+    draw_poly_as_mesh(scene, screen, poly)
+end
+
+function draw_poly_as_mesh(scene, screen, poly)
     draw_plot(scene, screen, poly.plots[1])
     draw_plot(scene, screen, poly.plots[2])
 end
 
 function draw_poly(scene::Scene, screen::CairoScreen, poly, points::Vector{<:Point2})
+
+    # in the rare case of per-vertex colors redirect to mesh drawing
+    if poly.color[] isa Array
+        draw_poly_as_mesh(scene, screen, poly)
+        return
+    end
+
     model = Mat4f0(I)
     points = project_position.(Ref(scene), points, Ref(model))
     Cairo.move_to(screen.context, points[1]...)


### PR DESCRIPTION
this brings down svg saving time for a couple of kde polys with 100 or so vertices to 80ms from a couple seconds for me. meshes seem to be quite slow, also they are overkill for polys with their single color