### PR TITLE
Switch over to glyphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.3"
 AbstractPlotting = "0.10.8"
 Cairo = "1"
 Colors = "0.9, 0.10, 0.11, 0.12"
@@ -23,13 +22,14 @@ FFTW = "1"
 FileIO = "1.1"
 FreeType = "3"
 GeometryBasics = "0.2"
-StaticArrays = "0.12"
 MakieGallery = "0.2.1"
+StaticArrays = "0.12"
+julia = "1.3"
 
 [extras]
+GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 MakieGallery = "dbd62bd0-c9f5-5087-a2e1-f5c4bb0cec90"
-GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -245,7 +245,8 @@ function draw_marker(ctx, marker::Char, font, pos, scale, strokecolor, strokewid
     # bottom left corner.
     Cairo.translate(ctx, centering_offset...)
 
-    Cairo.text_path(ctx, string(marker))
+    glyph = CairoGlyph(marker, font)
+    glyph_path(ctx, [glyph])
     Cairo.fill_preserve(ctx)
     # stroke
     Cairo.set_line_width(ctx, strokewidth)
@@ -309,7 +310,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Text)
         stridx = nextind(txt, stridx)
         pos = project_position(scene, p, Mat4f0(I))
         scale = project_scale(scene, ts, Mat4f0(I))
-        Cairo.move_to(ctx, pos[1], pos[2])
+        # Cairo.move_to(ctx, pos[1], pos[2])
+        Cairo.translate(ctx, pos[1], pos[2])
         Cairo.set_source_rgba(ctx, red(cc), green(cc), blue(cc), alpha(cc))
         cairoface = set_ft_font(ctx, f)
 
@@ -320,7 +322,9 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Text)
         Cairo.rotate(ctx, to_2d_rotation(r))
 
         if !(char in ('\r', '\n'))
-            Cairo.show_text(ctx, string(char))
+            glyph = CairoGlyph(char, f)
+            show_glyphs(ctx, [glyph])
+            # Cairo.show_text(ctx, string(char))
         end
 
         cairo_font_face_destroy(cairoface)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -245,8 +245,7 @@ function draw_marker(ctx, marker::Char, font, pos, scale, strokecolor, strokewid
     # bottom left corner.
     Cairo.translate(ctx, centering_offset...)
 
-    glyph = CairoGlyph(marker, font)
-    glyph_path(ctx, [glyph])
+    glyph_path(ctx, [CairoGlyph(marker, font)])
     Cairo.fill_preserve(ctx)
     # stroke
     Cairo.set_line_width(ctx, strokewidth)
@@ -283,7 +282,6 @@ function draw_marker(ctx, marker::Union{Rect, Type{<: Rect}}, pos, scale, stroke
         Cairo.stroke(ctx)
     end
 end
-
 
 ################################################################################
 #                                     Text                                     #
@@ -322,8 +320,7 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Text)
         Cairo.rotate(ctx, to_2d_rotation(r))
 
         if !(char in ('\r', '\n'))
-            glyph = CairoGlyph(char, f)
-            show_glyphs(ctx, [glyph])
+            show_glyphs(ctx, [CairoGlyph(char, f)])
             # Cairo.show_text(ctx, string(char))
         end
 


### PR DESCRIPTION
This is still early stage, and has yet to incorporate marker batching.

## Benchmarks:

### With glyphs
```julia
julia> @benchmark save("streamplot.png", scene)
BenchmarkTools.Trial: 
  memory estimate:  8.56 MiB
  allocs estimate:  359714
  --------------
  minimum time:     125.084 ms (0.00% GC)
  median time:      134.300 ms (0.00% GC)
  mean time:        138.612 ms (1.79% GC)
  maximum time:     174.034 ms (13.50% GC)
  --------------
  samples:          37
  evals/sample:     1

julia> @benchmark save("streamplot.pdf", scene)
BenchmarkTools.Trial: 
  memory estimate:  18.40 MiB
  allocs estimate:  682261
  --------------
  minimum time:     524.890 ms (0.00% GC)
  median time:      567.912 ms (0.00% GC)
  mean time:        567.293 ms (0.61% GC)
  maximum time:     595.558 ms (2.69% GC)
  --------------
  samples:          9
  evals/sample:     1

julia> @benchmark save("streamplot.svg", scene)
BenchmarkTools.Trial: 
  memory estimate:  8.55 MiB
  allocs estimate:  359572
  --------------
  minimum time:     128.375 ms (0.00% GC)
  median time:      136.864 ms (0.00% GC)
  mean time:        141.726 ms (1.91% GC)
  maximum time:     178.830 ms (14.72% GC)
  --------------
  samples:          36
  evals/sample:     1
```
### Without glyphs
```julia
julia> @benchmark save("streamplot.png", scene)
BenchmarkTools.Trial: 
  memory estimate:  8.54 MiB
  allocs estimate:  359714
  --------------
  minimum time:     123.997 ms (0.00% GC)
  median time:      134.350 ms (0.00% GC)
  mean time:        139.012 ms (1.95% GC)
  maximum time:     177.985 ms (15.72% GC)
  --------------
  samples:          37
  evals/sample:     1

julia> @benchmark save("streamplot.pdf", scene)
BenchmarkTools.Trial: 
  memory estimate:  18.39 MiB
  allocs estimate:  682261
  --------------
  minimum time:     534.316 ms (0.00% GC)
  median time:      549.414 ms (0.00% GC)
  mean time:        548.996 ms (0.55% GC)
  maximum time:     565.823 ms (0.00% GC)
  --------------
  samples:          10
  evals/sample:     1

julia> @benchmark save("streamplot.svg", scene)
BenchmarkTools.Trial: 
  memory estimate:  8.54 MiB
  allocs estimate:  359572
  --------------
  minimum time:     131.421 ms (0.00% GC)
  median time:      143.389 ms (0.00% GC)
  mean time:        145.518 ms (2.11% GC)
  maximum time:     180.238 ms (15.33% GC)
  --------------
  samples:          35
  evals/sample:     1
```

These benchmarks were taken from the streamplot example.