### PR TITLE
remove geomakie and test with new abstractplotting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AbstractPlotting = "0.11"
+AbstractPlotting = "0.11, 0.12"
 Cairo = "1"
 Colors = "0.9, 0.10, 0.11, 0.12"
 FFTW = "1"
@@ -27,10 +27,9 @@ StaticArrays = "0.12"
 julia = "1.3"
 
 [extras]
-GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 MakieGallery = "dbd62bd0-c9f5-5087-a2e1-f5c4bb0cec90"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MakieGallery", "ImageMagick", "GeoMakie", "Test"]
+test = ["MakieGallery", "ImageMagick", "Test"]


### PR DESCRIPTION
I've noticed that there is a GeoMakie test dependency that doesn't make a lot of sense. I've removed it, so we can allow a more recent AbstractPlotting version.

~Locally, this only fails one test that seems completely unrelated (`DataFrames` not installed, for the `iris` dataset example), so I guess it's good to merge.~ Not true! It actually fails a bunch of tests afterwards.