### PR TITLE
fix heatmap / image orientation

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -355,18 +355,22 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
     x, y = primitive[1][], primitive[2][]
     model = primitive[:model][]
     imsize = (extrema_nan(x), extrema_nan(y))
-    xy_ = project_position(scene, Point2f0(first.(imsize)), model)
-    xymax_ = project_position(scene, Point2f0(last.(imsize)), model)
-    xy = min.(xy_, xymax_)
-    xymax = max.(xy_, xymax_)
+
+    # find projected image corners
+    # this already takes care of flipping the image to correct cairo orientation
+    xy = project_position(scene, Point2f0(first.(imsize)), model)
+    xymax = project_position(scene, Point2f0(last.(imsize)), model)
+
+
     w, h = xymax .- xy
     interp = to_value(get(primitive, :interpolate, true))
     # TODO: use Gaussian blurring
     interp = interp ? Cairo.FILTER_BEST : Cairo.FILTER_NEAREST
+    
     s = to_cairo_image(image, primitive)
     Cairo.rectangle(ctx, xy..., w, h)
     Cairo.save(ctx)
-    Cairo.translate(ctx, xy[1], xy[2])
+    Cairo.translate(ctx, xy...)
     Cairo.scale(ctx, w / s.width, h / s.height)
     Cairo.set_source_surface(ctx, s, 0, 0)
     p = Cairo.get_source(ctx)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,21 +102,9 @@ function to_cairo_image(img::AbstractMatrix{<: Colorant}, attributes)
 end
 
 function to_cairo_image(img::Matrix{UInt32}, attributes)
-    # In Cairo, the y-axis is expected to go from the top
-    # to the bottom of the image, whereas in Makie we
-    # expect it to go from the bottom to the top.
-    # Therefore, we flip the y-axis here, to conform
-    # to Cairo's notion of the image direction.
-
-    # In addition, we are iterating over the y-axis first,
-    # such that the "first" axis of the image is what used to
-    # be the rows, instead of the columns.
-    # This conforms to the row-major matrix interface which
-    # Cairo expects.
-
-    # To achieve all of this, it is sufficient to physically
-    # rotate the matrix left by 90 degrees.
-    return Cairo.CairoARGBSurface(rotl90(img))
+    # we need to convert from column-major to row-major storage,
+    # therefore we permute x and y
+    return Cairo.CairoARGBSurface(permutedims(img))
 end
 
 


### PR DESCRIPTION
the code assumed that the projection would always be oriented a certain way, therefore ax.yreversed etc wouldn't work