### PR TITLE
add non-interpolated heatmap that works in vector graphics too

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -369,8 +369,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
     # graphics backends, but it's not directly visible from screen.surface what type we have
 
     if interp
-        # TODO: use Gaussian blurring
-        interp_flag = Cairo.FILTER_BEST
+        # FILTER_BEST doesn't work reliably with png backend, GAUSSIAN is not implemented
+        interp_flag = Cairo.FILTER_BILINEAR
         
         s = to_cairo_image(image, primitive)
         Cairo.rectangle(ctx, xy..., w, h)


### PR DESCRIPTION
This PR includes a "hack" to remove white lines between cells in svgs or pdfs. Those result from anti-aliasing at the borders and we can just make each cell a bit bigger than needed within the heatmap, as long as adjacent cells don't have alpha