### PR TITLE
Avoid 3D path for 2D objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 author = ["Simon Danisch <sdanisch@gmail.com>"]
 name = "CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"

--- a/src/overrides.jl
+++ b/src/overrides.jl
@@ -47,6 +47,12 @@ function draw_poly(scene::Scene, screen::CairoScreen, poly, points::Vector{<:Poi
     Cairo.stroke(screen.context)
 end
 
+function draw_poly(scene::Scene, screen::CairoScreen, poly, points_list::Vector{<:Vector{<:Point2}})
+    for points in points_list
+        draw_poly(scene, screen, poly, points)
+    end
+end
+
 
 draw_poly(scene::Scene, screen::CairoScreen, poly, rect::Rect2D) = draw_poly(scene, screen, poly, [rect])
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -454,7 +454,7 @@ end
 
 
 function draw_atomic(scene::Scene, screen::CairoScreen, primitive::AbstractPlotting.Mesh)
-    if scene.camera_controls[] isa Camera2D
+    if scene.camera_controls[] isa Union{Camera2D, AbstractPlotting.PixelCamera}
         draw_mesh2D(scene, screen, primitive)
     else
         if !haskey(primitive, :faceculling)


### PR DESCRIPTION
I found two cases where CairoMakie takes the "3D approach" for 2-dimensional objects:

1. when plotting a poly with `Vector{Vector{Point2f0}}`
2. when plotting a mesh and the camera is `PixelCamera`

This fixes both (I also upped the patch number because these issues break AlgebraOfGraphics, so it'd be great to make a patch release reasonably quickly).

To reproduces bug 1., the simplest is

```julia
using RDatasets: dataset
using AlgebraOfGraphics, CairoMakie
mpg = dataset("ggplot2", "mpg");
mpg.IsAudi = mpg.Manufacturer .== "audi"
geom = visual(BoxPlot, layout_x = 1) + visual(Violin, layout_x = 2)
data(mpg) *
    mapping(:Cyl => categorical, :Hwy) *
    mapping(dodge = :IsAudi => categorical, color = :IsAudi => categorical) *
    geom |> draw
AbstractPlotting.save("boxplot.svg", AbstractPlotting.current_scene());
```

For bug 2

```julia
using RDatasets: dataset
using AlgebraOfGraphics, CairoMakie
mpg = dataset("ggplot2", "mpg");
cols = mapping(:Displ, :Hwy);
grp = mapping(color = :Cyl => categorical);
scat = visual(Scatter) + linear
pipeline = cols * grp * scat
data(mpg) * pipeline |> draw
AbstractPlotting.save("scatter.svg", AbstractPlotting.current_scene());
```

They're both fixed with the PR.