### PR TITLE
`transpose` -> `permutedims`: fix `record`

### DIFF
--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -306,5 +306,5 @@ function AbstractPlotting.colorbuffer(screen::CairoScreen)
     cairo_draw(scr, scene)
 
     # x and y are flipped - return the transpose
-    return transpose(img)
+    return permutedims(img)
 end


### PR DESCRIPTION
The example
```julia
time = Node(0.0)

xs = LinRange(0, 7, 40)

ys_1 = @lift(sin.(xs .- $time))
ys_2 = @lift(cos.(xs .- $time) .+ 3)

scene = lines(xs, ys_1, color = :blue, linewidth = 4)
scatter!(scene, xs, ys_2, color = :red, markersize = 15)

timestamps = 0:1/30:2

record(scene, "time_animation.mp4", timestamps; framerate = 30) do t
    time[] = t
end
```
(or `record` more generally) does not work without this, which is due to
```julia
julia> using LinearAlgebra, Colors
julia> transpose(rand(RGBA{Float32}, 10, 10))
10×10 Transpose{Union{},Array{RGBA{Float32},2}}:
Error showing value of type Transpose{Union{},Array{RGBA{Float32},2}}:
ERROR: MethodError: no method matching transpose(::RGBA{Float32})
Closest candidates are:
  transpose(::Missing) at missing.jl:100
  transpose(::Number) at number.jl:168
  transpose(::Transpose) at C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.5\LinearAlgebra\src\adjtrans.jl:165
  ...
```

@SimonDanisch and I couldn't figure out why it worked before (I think it worked before? I've made gifs with CairoMakie + AbstractPlotting a few months ago at least).