### PR TITLE
Fix identifier conflict warning on package load

### DIFF
--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -23,7 +23,7 @@ const OneOrVec{T} = Union{
 
 # re-export AbstractPlotting
 for name in names(AbstractPlotting)
-    @eval import AbstractPlotting: $(name)
+    @eval using AbstractPlotting: $(name)
     @eval export $(name)
 end
 


### PR DESCRIPTION
Currently, if you load AbstractPlotting before CairoMakie, you get a warning that CairoMakie.AbstractPlotting conflicts with an existing identifier. This seems to happen due to the hard vs. soft binding distinction in `import` vs. `using`, respectively. If you swap the `import` for `using` when reexporting AbstractPlotting's symbols, the result is the same, but the warning disappears.