### PR TITLE
Lock the issue after closing it

### DIFF
--- a/.github/workflows/auto_close_all_issues.yml
+++ b/.github/workflows/auto_close_all_issues.yml
@@ -13,3 +13,6 @@ jobs:
             We do not accept issues on the CairoMakie.jl repository.
             Please open your issue on the Makie.jl repository instead:
             https://github.com/JuliaPlots/Makie.jl/issues
+      - uses: OSDKDev/lock-issues@v1.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It's best to lock the issue after closing it, to prevent further comments.