### PR TITLE
Fix a syntax error in auto_close_all_issues.yml

### DIFF
--- a/.github/workflows/auto_close_all_issues.yml
+++ b/.github/workflows/auto_close_all_issues.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.actor != 'JuliaTagBot'
-      - uses: peter-evans/close-issue@v1
+        uses: peter-evans/close-issue@v1
         with:
           comment: |
             We do not accept issues on the CairoMakie.jl repository.


### PR DESCRIPTION
The auto-close action isn't working currently because of a typo that I made. This PR fixes it.

@SimonDanisch 