### PR TITLE
Run tests from #864 before Pkg cmds

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,18 @@
 using Test, Pkg
 using CairoMakie
+
+# Before changing Pkg environment, try the test in #864
+@testset "Runs without error" begin
+    fig = Figure()
+    scatter(fig[1, 1], rand(10))
+    fn = tempname()*".png"
+    try
+        save(fn, fig)
+    finally
+        rm(fn)
+    end
+end
+
 path = normpath(joinpath(dirname(pathof(AbstractPlotting)), "..", "test", "ReferenceTests"))
 Pkg.develop(PackageSpec(path=path))
 using ReferenceTests


### PR DESCRIPTION
For reasons I don't fully understand, running this new test after
the `Pkg.develop` command doesn't catch the failure in #864,
although ImageMagick gives lots of warnings about failing to
map the value. Is that a sign that something is insufficiently
stringent elsewhere?