### PR TITLE
fix mesh/meshscatter for 2d scenes

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -472,7 +472,7 @@ function draw_mesh2D(scene, screen, primitive)
     colorrange = get(primitive, :colorrange, nothing) |> to_value
     ctx = screen.context
     model = primitive.model[]
-    mesh = primitive[1][]
+    mesh = GeometryBasics.mesh(primitive[1][])
     # Priorize colors of the mesh if present
     # This is a hack, which needs cleaning up in the Mesh plot type!
     color = hasproperty(mesh, :color) ? mesh.color : color

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -534,7 +534,7 @@ function draw_mesh3D(
     # Mesh data
     # transform to view/camera space
     vs = map(coordinates(mesh)) do v
-        p4d = to_ndim(Vec4f0, to_ndim(Vec3f0, scale, 1f0) .* to_ndim(Vec3f0, v, 0f0), 1f0)
+        p4d = to_ndim(Vec4f0, scale .* to_ndim(Vec3f0, v, 0f0), 1f0)
         view * (model * p4d .+ to_ndim(Vec4f0, pos, 0f0))
     end
     fs = faces(mesh)
@@ -699,8 +699,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::AbstractPlott
         scale = markersize isa Vector ? markersize[i] : markersize
 
         draw_mesh3D(
-            scene, screen, submesh,
-            mesh = m, pos = p, scale = scale
+            scene, screen, submesh, mesh = m, pos = p, 
+            scale = scale isa Real ? Vec3f0(scale) : to_ndim(Vec3f0, scale, 1f0)
         )
     end
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -534,7 +534,7 @@ function draw_mesh3D(
     # Mesh data
     # transform to view/camera space
     vs = map(coordinates(mesh)) do v
-        p4d = to_ndim(Vec4f0, scale * to_ndim(Vec3f0, v, 0f0), 1f0)
+        p4d = to_ndim(Vec4f0, to_ndim(Vec3f0, scale, 1f0) .* to_ndim(Vec3f0, v, 0f0), 1f0)
         view * (model * p4d .+ to_ndim(Vec4f0, pos, 0f0))
     end
     fs = faces(mesh)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -544,7 +544,7 @@ function draw_mesh3D(
 
     # Liight math happens in view/camera space
     if lightposition == :eyeposition
-        lightposition = scene.camera_controls[].eyeposition[]
+        lightposition = scene.camera.eyeposition[]
     end
     lightpos = (view * to_ndim(Vec4f0, lightposition, 1.0))[Vec(1, 2, 3)]
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,3 @@
-function AbstractPlotting.to_ndim(T::Type{<: VecTypes{N,ET}}, val, fillval) where {N,ET}
-    T(ntuple(Val(N)) do i
-        i == 1 && return ET(val)
-        ET(fillval)
-    end)
-end
-
-
 ################################################################################
 #                             Projection utilities                             #
 ################################################################################

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,11 @@
+function AbstractPlotting.to_ndim(T::Type{<: VecTypes{N,ET}}, val, fillval) where {N,ET}
+    T(ntuple(Val(N)) do i
+        i == 1 && return ET(val)
+        ET(fillval)
+    end)
+end
+
+
 ################################################################################
 #                             Projection utilities                             #
 ################################################################################


### PR DESCRIPTION
This crashes on master because we were using camera_controls instead of camera.
```julia
meshscatter([Point2f0(0), Point2f0(0,1), Point2f0(1,0), Point2f0(1)], marker=Rect(-0.5,-0.5,1,1), color=[1,2,3,4], markersize=1)
```

Also fixed issues with `Vec` and `Vector{<: Vec}` markersizes.