### PR TITLE
use png as default

### DIFF
--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -45,8 +45,9 @@ function display_path(type::String)
     return joinpath(@__DIR__, "display." * type)
 end
 
-function activate!(; inline = true, type = "png")
-    AbstractPlotting.current_backend[] = CairoBackend(display_path(type))
+function activate!(; inline = true, type = "png", px_per_unit=1, pt_per_unit=1)
+    backend = CairoBackend(display_path(type); px_per_unit=px_per_unit, pt_per_unit=pt_per_unit)
+    AbstractPlotting.current_backend[] = backend
     AbstractPlotting.use_display[] = !inline
     return
 end


### PR DESCRIPTION
See: https://discourse.julialang.org/t/cairomakie-and-fontconfig/55931
Also:

* I think png has the best support for all drawing primitives (e.g. images + heatmap can come out funky in svg)
* svgs can become huge for relatively normal sized plots

So chosing svg should be a concious choice when someone really needs those crisp vectors!