### PR TITLE
Fix inconsistent blending of multiple lines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 author = ["Simon Danisch <sdanisch@gmail.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -72,7 +72,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Lines, 
 end
 
 function draw_single(primitive::Lines, ctx, positions)
-    @inbounds for i in 1:length(positions)
+    n = length(positions)
+    @inbounds for i in 1:n
         p = positions[i]
         # only take action for non-NaNs
         if !isnan(p)
@@ -81,10 +82,13 @@ function draw_single(primitive::Lines, ctx, positions)
                 Cairo.move_to(ctx, p...)
             else
                 Cairo.line_to(ctx, p...)
+                # complete line segment at end or if next point is NaN
+                if i == n || isnan(positions[i+1])
+                    Cairo.stroke(ctx)
+                end
             end
         end
     end
-    Cairo.stroke(ctx)
 end
 
 function draw_single(primitive::LineSegments, ctx, positions)
@@ -92,11 +96,11 @@ function draw_single(primitive::LineSegments, ctx, positions)
     @inbounds for i in 1:length(positions)
         if iseven(i)
             Cairo.line_to(ctx, positions[i]...)
+            Cairo.stroke(ctx)
         else
             Cairo.move_to(ctx, positions[i]...)
         end
     end
-    Cairo.stroke(ctx)
 end
 
 # if linewidth is not an array


### PR DESCRIPTION
Fixes the inconsistency described in https://github.com/JuliaPlots/Makie.jl/issues/707.

Currently, on master the plot looks different depending on whether one calls `lines` multiple times or uses a single call of `lines` with `NaN` or `linesegments`:
```julia
using CairoMakie
lines([0.25,0.75],[0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
lines!([0.75,0.25],[0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_master_separate](https://user-images.githubusercontent.com/26102/114250852-5895e380-999f-11eb-9a09-9c31e04d4182.png)
```julia
using CairoMakie
lines([0.25,0.75,NaN,0.75,0.25],[0.25,0.75,NaN,0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_master_joint](https://user-images.githubusercontent.com/26102/114250889-77947580-999f-11eb-8850-dfacb25b0e45.png)
```julia
using CairoMakie
linesegments([0.25,0.75,0.75,0.25],[0.25,0.75,0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_master_segments](https://user-images.githubusercontent.com/26102/114250905-85e29180-999f-11eb-9a49-aa460a45edbf.png)

With this PR, one gets instead:
```julia
using CairoMakie
lines([0.25,0.75],[0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
lines!([0.75,0.25],[0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_fix_separate](https://user-images.githubusercontent.com/26102/114250927-96930780-999f-11eb-9cef-2997525d5927.png)
```julia
using CairoMakie
lines([0.25,0.75,NaN,0.75,0.25],[0.25,0.75,NaN,0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_fix_joint](https://user-images.githubusercontent.com/26102/114250933-9dba1580-999f-11eb-80b8-4b883ba62a14.png)
```julia
using CairoMakie
linesegments([0.25,0.75,0.75,0.25],[0.25,0.75,0.25,0.75],color=RGBA(0,0,0,0.5),linewidth=30)
```
![test_fix_segments](https://user-images.githubusercontent.com/26102/114250940-a0b50600-999f-11eb-8b2e-25865902ed48.png)

