### PR TITLE
fix blurry image edges with EXTEND_PAD

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -461,6 +461,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
         Cairo.scale(ctx, w / s.width, h / s.height)
         Cairo.set_source_surface(ctx, s, 0, 0)
         p = Cairo.get_source(ctx)
+        # this is needed to avoid blurry edges
+        Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
         # Set filter doesn't work!?
         Cairo.pattern_set_filter(p, interp_flag)
         Cairo.fill(ctx)


### PR DESCRIPTION
bitmaps otherwise have a white edge

before:

<img width="491" alt="grafik" src="https://user-images.githubusercontent.com/22495855/114526250-1989bb80-9c47-11eb-92b1-0dcde572afa3.png">

after:

<img width="490" alt="grafik" src="https://user-images.githubusercontent.com/22495855/114526185-0840af00-9c47-11eb-8d2f-3a738a69292c.png">
