### PR TITLE
Set `LIB_CAIRO` at module init time.

### DIFF
--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -32,7 +32,6 @@ include("primitives.jl")
 include("overrides.jl")
 
 function __init__()
-    global LIB_CAIRO = isdefined(Cairo, :libcairo) ? Cairo.libcairo : Cairo._jl_libcairo
     activate!()
     Makie.register_backend!(Makie.current_backend[])
 end

--- a/src/CairoMakie.jl
+++ b/src/CairoMakie.jl
@@ -11,11 +11,6 @@ using Makie: convert_attribute, @extractvalue, LineSegments, to_ndim, NativeFont
 using Makie: @info, @get_attribute, Combined
 using Makie: to_value, to_colormap, extrema_nan
 using Makie: inline!
-const LIB_CAIRO = if isdefined(Cairo, :libcairo)
-    Cairo.libcairo
-else
-    Cairo._jl_libcairo
-end
 
 const OneOrVec{T} = Union{
     T,
@@ -37,6 +32,7 @@ include("primitives.jl")
 include("overrides.jl")
 
 function __init__()
+    global LIB_CAIRO = isdefined(Cairo, :libcairo) ? Cairo.libcairo : Cairo._jl_libcairo
     activate!()
     Makie.register_backend!(Makie.current_backend[])
 end

--- a/src/fonts.jl
+++ b/src/fonts.jl
@@ -1,16 +1,16 @@
 function set_font_matrix(ctx, matrix)
-    ccall((:cairo_set_font_matrix, LIB_CAIRO), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, Ref(matrix))
+    ccall((:cairo_set_font_matrix, Cairo.libcairo), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, Ref(matrix))
 end
 
 function get_font_matrix(ctx)
     matrix = Cairo.CairoMatrix()
-    ccall((:cairo_get_font_matrix, LIB_CAIRO), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, Ref(matrix))
+    ccall((:cairo_get_font_matrix, Cairo.libcairo), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, Ref(matrix))
     return matrix
 end
 
 function cairo_font_face_destroy(font_face)
     ccall(
-        (:cairo_font_face_destroy, LIB_CAIRO),
+        (:cairo_font_face_destroy, Cairo.libcairo),
         Cvoid, (Ptr{Cvoid},),
         font_face
     )
@@ -19,12 +19,12 @@ end
 function set_ft_font(ctx, font)
 
     font_face = ccall(
-        (:cairo_ft_font_face_create_for_ft_face, LIB_CAIRO),
+        (:cairo_ft_font_face_create_for_ft_face, Cairo.libcairo),
         Ptr{Cvoid}, (Makie.FreeTypeAbstraction.FT_Face, Cint),
         font, 0
     )
 
-    ccall((:cairo_set_font_face, LIB_CAIRO), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, font_face)
+    ccall((:cairo_set_font_face, Cairo.libcairo), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), ctx.ptr, font_face)
 
     return font_face
 end

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -67,7 +67,7 @@ function CairoScreen(scene::Scene; device_scaling_factor = 1, antialias = Cairo.
     # this sets a scaling factor on the lowest level that is "hidden" so its even
     # enabled when the drawing space is reset for strokes
     # that means it can be used to increase or decrease the image resolution
-    ccall((:cairo_surface_set_device_scale, LIB_CAIRO), Cvoid, (Ptr{Nothing}, Cdouble, Cdouble),
+    ccall((:cairo_surface_set_device_scale, Cairo.libcairo), Cvoid, (Ptr{Nothing}, Cdouble, Cdouble),
         surf.ptr, device_scaling_factor, device_scaling_factor)
 
     ctx = Cairo.CairoContext(surf)


### PR DESCRIPTION
Setting it at the module toplevel was causing issues for `PackageCompiler` since it meant the path wasn't relocatable. Setting it in `__init__` should resolve that.