### PR TITLE
draw rects for heatmap for vector backends

### DIFF
--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -76,10 +76,15 @@ function CairoScreen(scene::Scene; device_scaling_factor = 1, antialias = Cairo.
     return CairoScreen(scene, surf, ctx, nothing)
 end
 
+function get_type(surface::Cairo.CairoSurface)
+    return ccall((:cairo_surface_get_type, Cairo.libcairo), Cint, (Ptr{Nothing},), surface.ptr)
+end
+
 is_vector_backend(ctx::Cairo.CairoContext) = is_vector_backend(ctx.surface)
 
 function is_vector_backend(surf::Cairo.CairoSurface)
-    return surf isa Union{Cairo.CairoSVGSurface, Cairo.CairoPDFSurface, Cairo.CairoEPSSurface}
+    typ = get_type(surf)
+    return typ in (Cairo.CAIRO_SURFACE_TYPE_PDF, Cairo.CAIRO_SURFACE_TYPE_PS, Cairo.CAIRO_SURFACE_TYPE_SVG)
 end
 
 """

--- a/src/infrastructure.jl
+++ b/src/infrastructure.jl
@@ -76,6 +76,11 @@ function CairoScreen(scene::Scene; device_scaling_factor = 1, antialias = Cairo.
     return CairoScreen(scene, surf, ctx, nothing)
 end
 
+is_vector_backend(ctx::Cairo.CairoContext) = is_vector_backend(ctx.surface)
+
+function is_vector_backend(surf::Cairo.CairoSurface)
+    return surf isa Union{Cairo.CairoSVGSurface, Cairo.CairoPDFSurface, Cairo.CairoEPSSurface}
+end
 
 """
     CairoScreen(
@@ -319,7 +324,7 @@ function Makie.backend_show(x::CairoBackend, io::IO, ::MIME"application/postscri
     return screen
 end
 
-function Makie.backend_show(x::CairoBackend, io::IO, m::MIME"image/png", scene::Scene)
+function Makie.backend_show(x::CairoBackend, io::IO, ::MIME"image/png", scene::Scene)
 
     # multiply the resolution of the png with this factor for more or less detail
     # while relative line and font sizes are unaffected

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -496,7 +496,8 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
     # theoretically, we could restrict the non-interpolation vector graphics hack to actual vector
     # graphics backends, but it's not directly visible from screen.surface what type we have
     weird_cairo_limit = (2^15) - 23
-    if xs isa AbstractRange && ys isa AbstractRange
+    # Vector backends don't support FILTER_NEAREST for interp == false, so in that case we also need to draw rects
+    if xs isa AbstractRange && ys isa AbstractRange && !(is_vector_backend(ctx) && !interp)
         # find projected image corners
         # this already takes care of flipping the image to correct cairo orientation
         xy = project_position(scene, Point2f0(first.(imsize)), model)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -493,8 +493,6 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
 
     interp = to_value(get(primitive, :interpolate, true))
 
-    # theoretically, we could restrict the non-interpolation vector graphics hack to actual vector
-    # graphics backends, but it's not directly visible from screen.surface what type we have
     weird_cairo_limit = (2^15) - 23
     # Vector backends don't support FILTER_NEAREST for interp == false, so in that case we also need to draw rects
     if xs isa AbstractRange && ys isa AbstractRange && !(is_vector_backend(ctx) && !interp)
@@ -525,6 +523,7 @@ function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap
         Cairo.restore(ctx)
 
     else
+        # We need to draw rectangles for vector backends, or irregular grids
         if interp
             error("Interpolation for non gridded heatmaps/images isn't supported right now. Please use interpolate=false for this plot")
         end


### PR DESCRIPTION
The fastpath I introduced earlier didn't account for Cairos annoying inconsistencies....